### PR TITLE
Bump RVO component-library-css to 4.20.1 and design-tokens to 2.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # [Unreleased]
 - ...
 
+# [0.5] - 2026-04-29
+- Upgraded `@nl-rvo/component-library-css` from `4.19.0` to `4.20.1`
+- Upgraded `@nl-rvo/design-tokens` from `2.2.0` to `2.4.0`: adds design tokens for new tabs v2 component
+
 # [0.4] - 2026-03-18
 - Upgraded `@nl-rvo/assets` from `1.0.0-alpha.360` to `1.0.0`
 - Upgraded `@nl-rvo/component-library-css` from `4.7.0` to `4.19.0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@nl-rvo/assets": "1.0.0",
-        "@nl-rvo/component-library-css": "4.19.0",
+        "@nl-rvo/component-library-css": "4.20.1",
         "@nl-rvo/css-button": "2.1.0",
-        "@nl-rvo/design-tokens": "2.2.0",
+        "@nl-rvo/design-tokens": "2.4.0",
         "htmx.org": "^1.9.12",
         "reset-css": "^5.0.2"
       },
@@ -834,9 +834,9 @@
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@nl-rvo/component-library-css": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@nl-rvo/component-library-css/-/component-library-css-4.19.0.tgz",
-      "integrity": "sha512-GLkD7hM+sIzin/5He3xRF3GBGP9Rz7j6gF4+D3jWL1+ylH+TO+f4BClKb2PQ3Zk8Od2txsseIBKK69PvZFYqEA==",
+      "version": "4.20.1",
+      "resolved": "https://registry.npmjs.org/@nl-rvo/component-library-css/-/component-library-css-4.20.1.tgz",
+      "integrity": "sha512-Z/3euS7wh9iqZvTjO539lYAXRqqk71q7552Ze1ZnNRRzLGzh5uv0dINWkcessSjrnxzvLeG458GRMY+qhaUDtA==",
       "license": "CC0-1.0",
       "dependencies": {
         "modern-normalize": "3.0.1"
@@ -853,9 +853,9 @@
       }
     },
     "node_modules/@nl-rvo/design-tokens": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nl-rvo/design-tokens/-/design-tokens-2.2.0.tgz",
-      "integrity": "sha512-3xPXGP1O4fOba+gfo7aJcZk0PlCHsbsAMP5qYPjELe0P+0etsnzd60jor8/0RdzeNNlSwiFzVtdOLjT6Ks6W5A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@nl-rvo/design-tokens/-/design-tokens-2.4.0.tgz",
+      "integrity": "sha512-Gn8D3vY9DRMFORZyX6yqzLlLkQdYMpbL2BsKwhknkHsrDdkgjDH75vvtMENd5yZkzjhQ7/nzOCktFpFdIvz5cA==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
   },
   "dependencies": {
     "@nl-rvo/assets": "1.0.0",
-    "@nl-rvo/component-library-css": "4.19.0",
+    "@nl-rvo/component-library-css": "4.20.1",
     "@nl-rvo/css-button": "2.1.0",
-    "@nl-rvo/design-tokens": "2.2.0",
+    "@nl-rvo/design-tokens": "2.4.0",
     "htmx.org": "^1.9.12",
     "reset-css": "^5.0.2"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "jinja-roos-components"
-version = "0.4"
+version = "0.5"
 description = "Modern, self-contained Jinja2 component library with built-in assets"
 readme = "README.md"
 license = {text = "EUPL"}

--- a/src/jinja_roos_components/static/roos/dist/@nl-rvo/component-library-css/index.css
+++ b/src/jinja_roos_components/static/roos/dist/@nl-rvo/component-library-css/index.css
@@ -2669,19 +2669,19 @@ h3.rvo-accordion__item-title {
 
 .utrecht-radio-button--focus {
   --_utrecht-radio-button-interactive-background-color: var(
-    --utrecht-radio-button-focus-background-color,
+    --_utrecht-radio-button-state-focus-background-color,
     var(--utrecht-radio-button-focus-background-color)
   );
   --_utrecht-radio-button-interactive-border-color: var(
-    --utrecht-radio-button-focus-border-color,
+    --_utrecht-radio-button-state-focus-border-color,
     var(--utrecht-radio-button-focus-border-color)
   );
   --_utrecht-radio-button-interactive-border-width: var(
-    --utrecht-radio-button-focus-border-width,
+    --_utrecht-radio-button-state-focus-border-width,
     var(--utrecht-radio-button-focus-border-width)
   );
   --_utrecht-radio-button-interactive-color: var(
-    --utrecht-radio-button-focus-color,
+    --_utrecht-radio-button-state-focus-color,
     var(--utrecht-radio-button-focus-color)
   );
 }
@@ -2808,19 +2808,19 @@ h3.rvo-accordion__item-title {
 
 .utrecht-radio-button--html-input:focus:not([aria-disabled=true], :disabled) {
   --_utrecht-radio-button-interactive-background-color: var(
-    --utrecht-radio-button-focus-background-color,
+    --_utrecht-radio-button-state-focus-background-color,
     var(--utrecht-radio-button-focus-background-color)
   );
   --_utrecht-radio-button-interactive-border-color: var(
-    --utrecht-radio-button-focus-border-color,
+    --_utrecht-radio-button-state-focus-border-color,
     var(--utrecht-radio-button-focus-border-color)
   );
   --_utrecht-radio-button-interactive-border-width: var(
-    --utrecht-radio-button-focus-border-width,
+    --_utrecht-radio-button-state-focus-border-width,
     var(--utrecht-radio-button-focus-border-width)
   );
   --_utrecht-radio-button-interactive-color: var(
-    --utrecht-radio-button-focus-color,
+    --_utrecht-radio-button-state-focus-color,
     var(--utrecht-radio-button-focus-color)
   );
 }
@@ -3001,6 +3001,7 @@ h3.rvo-accordion__item-title {
   outline-offset: var(--utrecht-focus-outline-offset, revert);
   outline-style: var(--utrecht-focus-outline-style, revert);
   outline-width: var(--utrecht-focus-outline-width, revert);
+  z-index: 1;
 }
 
 .utrecht-select--busy {
@@ -3041,6 +3042,7 @@ h3.rvo-accordion__item-title {
   outline-offset: var(--utrecht-focus-outline-offset, revert);
   outline-style: var(--utrecht-focus-outline-style, revert);
   outline-width: var(--utrecht-focus-outline-width, revert);
+  z-index: 1;
 }
 
 .utrecht-select--html-select:disabled {
@@ -3149,6 +3151,7 @@ h3.rvo-accordion__item-title {
   border-style: solid;
   box-sizing: border-box;
   color: var(--utrecht-textbox-color, var(--utrecht-form-control-color));
+  display: block;
   font-family: var(--utrecht-textbox-font-family, var(--utrecht-form-control-font-family));
   font-size: var(--utrecht-textbox-font-size, var(--utrecht-form-control-font-size, inherit));
   font-weight: var(--utrecht-textbox-font-weight, var(--utrecht-form-control-font-weight, initial));
@@ -3157,10 +3160,12 @@ h3.rvo-accordion__item-title {
   min-block-size: var(--utrecht-pointer-target-min-size, 44px);
   min-inline-size: var(--utrecht-pointer-target-min-size, 44px);
   max-inline-size: min(var(--_utrecht-textbox-max-inline-size, 100%), var(--utrecht-textbox-max-inline-size, var(--utrecht-form-control-max-inline-size)));
+  overflow: hidden;
   padding-block-end: var(--utrecht-textbox-padding-block-end, var(--utrecht-form-control-padding-block-end, 0));
   padding-block-start: var(--utrecht-textbox-padding-block-start, var(--utrecht-form-control-padding-block-start, 0));
   padding-inline-end: var(--utrecht-textbox-padding-inline-end, var(--utrecht-form-control-padding-inline-end, initial));
   padding-inline-start: var(--utrecht-textbox-padding-inline-start, var(--utrecht-form-control-padding-inline-start, initial));
+  white-space: nowrap;
 }
 
 .utrecht-textbox--invalid {
@@ -3199,6 +3204,7 @@ h3.rvo-accordion__item-title {
   outline-offset: var(--utrecht-focus-outline-offset, revert);
   outline-style: var(--utrecht-focus-outline-style, revert);
   outline-width: var(--utrecht-focus-outline-width, revert);
+  z-index: 1;
 }
 
 .utrecht-textbox--read-only {
@@ -3285,9 +3291,10 @@ h3.rvo-accordion__item-title {
   outline-offset: var(--utrecht-focus-outline-offset, revert);
   outline-style: var(--utrecht-focus-outline-style, revert);
   outline-width: var(--utrecht-focus-outline-width, revert);
+  z-index: 1;
 }
 
-.utrecht-textbox--html-input:invalid, .utrecht-textbox--html-input[aria-invalid=true] {
+.utrecht-textbox--html-input:user-invalid, .utrecht-textbox--html-input[aria-invalid=true] {
   --_utrecht-textbox-border-width: var(
     --utrecht-textbox-invalid-border-width,
     var(
@@ -3337,6 +3344,7 @@ h3.rvo-accordion__item-title {
 
 .utrecht-textbox {
   --utrecht-pointer-target-min-size: 48px;
+  height: var(--utrecht-pointer-target-min-size, 48px);
 }
 
 textarea.utrecht-textbox {
@@ -3470,8 +3478,8 @@ textarea.utrecht-textbox {
 }
 
 .utrecht-textarea--read-only {
-  background-color: var(--utrecht-textarea-read-only-border, var(--utrecht-form-control-read-only-background-color, var(--utrecht-textarea-border, var(--utrecht-form-control-background-color))));
-  border-color: var(--utrecht-textarea-read-only-border, var(--utrecht-form-control-read-only-border-color, var(--utrecht-textarea-border, var(--utrecht-form-control-border-color))));
+  background-color: var(--utrecht-textarea-read-only-background-color, var(--utrecht-form-control-read-only-background-color, var(--utrecht-textarea-background-color, var(--utrecht-form-control-background-color))));
+  border-color: var(--utrecht-textarea-read-only-border-color, var(--utrecht-form-control-read-only-border-color, var(--utrecht-textarea-border-color, var(--utrecht-form-control-border-color))));
   color: var(--utrecht-textarea-read-only-color, var(--utrecht-form-control-read-only-color, var(--utrecht-textarea-color, var(--utrecht-form-control-color))));
 }
 
@@ -3514,8 +3522,8 @@ textarea.utrecht-textbox {
 }
 
 .utrecht-textarea--html-textarea:read-only {
-  background-color: var(--utrecht-textarea-read-only-border, var(--utrecht-form-control-read-only-background-color, var(--utrecht-textarea-border, var(--utrecht-form-control-background-color))));
-  border-color: var(--utrecht-textarea-read-only-border, var(--utrecht-form-control-read-only-border-color, var(--utrecht-textarea-border, var(--utrecht-form-control-border-color))));
+  background-color: var(--utrecht-textarea-read-only-background-color, var(--utrecht-form-control-read-only-background-color, var(--utrecht-textarea-background-color, var(--utrecht-form-control-background-color))));
+  border-color: var(--utrecht-textarea-read-only-border-color, var(--utrecht-form-control-read-only-border-color, var(--utrecht-textarea-border-color, var(--utrecht-form-control-border-color))));
   color: var(--utrecht-textarea-read-only-color, var(--utrecht-form-control-read-only-color, var(--utrecht-textarea-color, var(--utrecht-form-control-color))));
 }
 
@@ -3895,9 +3903,6 @@ textarea.rvo-textarea--md {
   color: var(--rvo-color-lintblauw);
   display: flex;
 }
-.rvo-heading .rvo-icon {
-  --utrecht-icon-color: var(--rvo-color-lintblauw);
-}
 .rvo-heading--normal {
   font-weight: var(--rvo-font-weight-normal);
 }
@@ -3931,20 +3936,12 @@ textarea.rvo-textarea--md {
   margin-block-end: var(--utrecht-heading-6-margin-block-end);
   margin-block-start: var(--utrecht-heading-6-margin-block-start);
 }
-
-h1.rvo-heading .rvo-icon,
-h2.rvo-heading .rvo-icon {
-  --utrecht-icon-size: var(--rvo-icon-xl-width);
+.rvo-heading__icon {
+  display: flex;
 }
-
-h3.rvo-heading .rvo-icon,
-h4.rvo-heading .rvo-icon {
-  --utrecht-icon-size: var(--rvo-icon-lg-width);
-}
-
-h5.rvo-heading .rvo-icon,
-h6.rvo-heading .rvo-icon {
-  --utrecht-icon-size: var(--rvo-icon-md-width);
+.rvo-heading__content {
+  display: block;
+  font-size: inherit;
 }
 
 /**
@@ -3961,6 +3958,7 @@ h6.rvo-heading .rvo-icon {
  * Copyright (c) 2021 Community for NL Design System
  */
 .rvo-hero {
+  border-end-end-radius: var(--rvo-hero-border-end-end-radius);
   margin-inline-end: auto;
   margin-inline-start: auto;
   min-height: 200px;
@@ -3969,17 +3967,21 @@ h6.rvo-heading .rvo-icon {
 }
 .rvo-hero .rvo-hero__content {
   background-color: var(--rvo-hero-box-background-color);
-  border-start-end-radius: var(--rvo-hero-box-border-start-end-radius);
-  bottom: 0;
   color: var(--rvo-hero-title-color);
   margin-block-end: 0;
-  max-width: var(--rvo-hero-box-max-width);
   padding-block-end: var(--rvo-hero-box-padding-block-end);
   padding-block-start: var(--rvo-hero-box-padding-block-start);
   padding-inline-end: var(--rvo-hero-box-padding-inline-end);
   padding-inline-start: var(--rvo-hero-box-padding-inline-start);
-  position: absolute;
-  z-index: 1;
+}
+@media (min-width: 540px) {
+  .rvo-hero .rvo-hero__content {
+    border-start-end-radius: var(--rvo-hero-box-border-start-end-radius);
+    bottom: 0;
+    max-width: var(--rvo-hero-box-max-width);
+    position: absolute;
+    z-index: 1;
+  }
 }
 .rvo-hero .rvo-hero__title,
 .rvo-hero .rvo-hero__subtitle {
@@ -3992,33 +3994,27 @@ h6.rvo-heading .rvo-icon {
   font-weight: var(--rvo-hero-subtitle-font-weight);
   line-height: var(--rvo-hero-subtitle-line-height);
 }
-.rvo-hero--lichtblauw .rvo-hero__content {
-  background-color: var(--rvo-hero-kind-lichtblauw-background-color);
-  color: var(--rvo-hero-kind-lichtblauw-color);
+.rvo-hero--violet {
+  --rvo-hero-box-background-color: var(--rvo-color-violet);
 }
-.rvo-hero--lichtblauw .rvo-hero__title, .rvo-hero--lichtblauw .rvo-hero__subtitle {
+.rvo-hero--lichtblauw {
+  --rvo-hero-box-background-color: var(--rvo-hero-kind-lichtblauw-background-color);
+}
+.rvo-hero--lichtblauw .rvo-hero__content,
+.rvo-hero--lichtblauw .rvo-hero__title,
+.rvo-hero--lichtblauw .rvo-hero__subtitle {
   color: var(--rvo-hero-kind-lichtblauw-color);
 }
 
 .rvo-hero__image-container {
   line-height: 0;
-  min-height: 300px;
   overflow: hidden;
-  padding-block-end: 20%;
 }
 @media (min-width: 540px) {
   .rvo-hero__image-container {
     max-height: 500px;
-  }
-}
-@media (min-width: 540px) {
-  .rvo-hero__image-container {
+    min-height: 300px;
     padding-block-end: 0;
-  }
-}
-@media (min-width: 780px) {
-  .rvo-hero__image-container {
-    border-end-end-radius: var(--rvo-hero-border-end-end-radius);
   }
 }
 .rvo-hero__image-container--lined::after {
@@ -4042,6 +4038,7 @@ h6.rvo-heading .rvo-icon {
 
 .rvo-hero__image {
   height: 100%;
+  min-height: 300px;
   object-fit: cover;
   width: 100%;
 }
@@ -4058,13 +4055,8 @@ h6.rvo-heading .rvo-icon {
  */
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021-2022 Gemeente Utrecht
- * Copyright (c) 2021-2022 Frameless B.V.
- */
-/**
- * @license EUPL-1.2
- * Copyright (c) 2021-2022 Gemeente Utrecht
- * Copyright (c) 2021-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 .utrecht-icon {
   block-size: var(--utrecht-icon-size);
@@ -4077,17 +4069,8 @@ h6.rvo-heading .rvo-icon {
 }
 
 .utrecht-icon svg {
-  /*
-   * Override the width of SVGs when they are hardcoded, and avoid oversized SVG icons.
-   * For example:
-   * 
-   *   <svg width="128px" height="128px">
-   */
-  /* stylelint-disable-next-line property-disallowed-list */
   height: 100%;
-  /* Remove tooltip from SVG `<title>` element using `pointer-events: none` */
   pointer-events: none;
-  /* stylelint-disable-next-line property-disallowed-list */
   width: 100%;
 }
 
@@ -5246,55 +5229,116 @@ h6.rvo-heading .rvo-icon {
   text-align: end;
 }
 
-/**
- * @license CC0-1.0
- * Copyright (c) 2021 Community for NL Design System
- */
-.rvo-tabs__item {
-  list-style: none;
+.rvo-tabs {
+  --rvo-tabs-padding-block: var(--rvo-tabs-padding-block-start, --rvo-space-xs)
+    var(--rvo-tabs-padding-block-end, --rvo-space-xs);
+  --rvo-tabs-padding-inline: var(--rvo-tabs-padding-inline-start, --rvo-space-md)
+    var(--rvo-tabs-padding-inline-end, --rvo-space-md);
+  --rvo-tabs-panel-padding-block: var(--rvo-tabs-panel-padding-block-start, --rvo-space-xs)
+    var(--rvo-tabs-panel-padding-block-end, --rvo-space-xs);
+  --rvo-tabs-panel-padding-inline: var(--rvo-tabs-panel-padding-inline-start, --rvo-space-md)
+    var(--rvo-tabs-panel-padding-inline-end, --rvo-space-md);
+  font-size: var(--rvo-tabs-font-size);
 }
-.rvo-tabs__item .rvo-tabs__item-link {
-  font-weight: var(--rvo-tabs-font-weight);
+.rvo-tabs__tablist {
+  align-items: flex-end;
+  border-bottom: var(--rvo-tabs-border-width) var(--rvo-tabs-border-style) var(--rvo-tabs-border-color);
+  display: flex;
+  gap: var(--rvo-tabs-gap);
+  margin-block: calc(var(--rvo-tabs-border-width) * -1);
+  padding-inline: 0;
+  position: relative;
 }
-.rvo-tabs__item .rvo-tabs__item-link--active {
+.rvo-tabs__tablist::after {
+  border-block-end: var(--rvo-tabs-border-width) var(--rvo-tabs-border-style) var(--rvo-tabs-border-color);
+  bottom: calc(var(--rvo-tabs-border-width) * -1);
+  content: "";
+  left: 0;
+  position: absolute;
+  right: 0;
+  z-index: 2;
+}
+.rvo-tabs__item, .rvo-tabs__tab {
+  align-items: center;
+  appearance: none;
+  background-color: var(--rvo-tabs-background);
+  border: var(--rvo-tabs-border-width) var(--rvo-tabs-border-style) transparent;
+  border-block-end: none;
+  border-block-end-color: var(--rvo-tabs-border-color);
+  color: var(--rvo-tabs-color);
+  column-gap: var(--rvo-tabs-gap);
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-weight: 500;
+  margin-block-end: calc(var(--rvo-tabs-border-width) * -1);
+  margin-block-start: var(--rvo-tabs-border-width);
+  padding-block: var(--rvo-tabs-padding-block);
+  padding-inline: var(--rvo-tabs-padding-inline);
+  position: relative;
+  text-decoration: underline;
+  user-select: none;
+  z-index: 0;
+}
+.rvo-tabs__item:hover, .rvo-tabs__tab:hover {
+  text-decoration: none;
+}
+.rvo-tabs__item:focus-visible, .rvo-tabs__tab:focus-visible {
+  outline: var(--rvo-tabs-focus-width) var(--rvo-tabs-border-style) var(--rvo-tabs-focus-color);
+  outline-offset: var(--rvo-tabs-focus-offset);
+  z-index: 3;
+}
+.rvo-tabs__item + .rvo-tabs__item, .rvo-tabs__item + .rvo-tabs__tab, .rvo-tabs__tab + .rvo-tabs__item, .rvo-tabs__tab + .rvo-tabs__tab {
+  margin-inline-start: calc(var(--rvo-tabs-border-width) * -1);
+}
+.rvo-tabs__item--active, .rvo-tabs__tab--active {
+  background-color: var(--rvo-tabs-active-background);
+  border-color: var(--rvo-tabs-border-color);
+  color: var(--rvo-tabs-active-color);
   font-weight: var(--rvo-tabs-active-font-weight);
+  text-decoration: none;
+  z-index: 3;
+}
+.rvo-tabs__item--active:hover, .rvo-tabs__tab--active:hover {
+  background-color: var(--rvo-tabs-active-background);
+}
+.rvo-tabs__item--disabled, .rvo-tabs__item:disabled, .rvo-tabs__tab--disabled, .rvo-tabs__tab:disabled {
+  cursor: not-allowed;
+  opacity: 55%;
+}
+.rvo-tabs__panel {
+  background-color: var(--rvo-tabs-active-background);
+  border: var(--rvo-tabs-panel-border-width) var(--rvo-tabs-panel-border-style) var(--rvo-tabs-panel-border-color);
+  border-top: 0;
+  padding-block: var(--rvo-tabs-panel-padding-block);
+  padding-inline: var(--rvo-tabs-panel-padding-inline);
+  position: relative;
+  z-index: 1;
+}
+.rvo-tabs__panel:focus-visible {
+  border: var(--rvo-tabs-panel-border-width) var(--rvo-tabs-panel-border-style) var(--rvo-tabs-panel-border-color);
+  outline-offset: var(--rvo-tabs-focus-offset);
+}
+.rvo-tabs__panel--no-border {
+  --rvo-tabs-panel-border-width: 0;
+}
+.rvo-tabs__panel--no-padding {
+  --rvo-tabs-panel-padding-inline: 0;
+  --rvo-tabs-panel-padding-block: 0;
+}
+.rvo-tabs--sm {
+  --rvo-tabs-font-size: var(--rvo-font-size-sm, --rvo-space-sm);
+  --rvo-tabs-gap: var(--rvo-space-2xs, --rvo-space-2xs);
+}
+.rvo-tabs--md {
+  --rvo-tabs-font-size: var(--rvo-font-size-md, --rvo-space-md);
+  --rvo-tabs-gap: var(--rvo-space-xs, --rvo-space-xs);
+}
+.rvo-tabs--lg {
+  --rvo-tabs-font-size: var(--rvo-font-size-lg, --rvo-space-lg);
+  --rvo-tabs-gap: var(--rvo-space-xs, --rvo-space-xs);
 }
 
-@media (min-width: 600px) {
-  .rvo-tabs {
-    display: inline-flex;
-  }
-  .rvo-tabs li.rvo-tabs__item::before {
-    display: none;
-  }
-  .rvo-tabs li.rvo-tabs__item .rvo-tabs__item-link {
-    border-bottom-color: var(--rvo-tabs-border-bottom-color);
-    border-bottom-style: var(--rvo-tabs-border-bottom-style);
-    border-bottom-width: var(--rvo-tabs-border-bottom-width);
-    color: var(--rvo-tabs-color);
-    margin-block-end: -1px;
-    padding-block-end: var(--rvo-tabs-padding-block-end);
-    padding-block-start: var(--rvo-tabs-padding-block-start);
-    padding-inline-end: var(--rvo-tabs-padding-inline-end);
-    padding-inline-start: var(--rvo-tabs-padding-inline-start);
-    text-decoration: none;
-  }
-  .rvo-tabs li.rvo-tabs__item .rvo-tabs__item-link:hover {
-    border-bottom-color: var(--rvo-tabs-hover-border-bottom-color);
-    border-bottom-style: var(--rvo-tabs-hover-border-bottom-style);
-    border-bottom-width: var(--rvo-tabs-hover-border-bottom-width);
-  }
-  .rvo-tabs li.rvo-tabs__item .rvo-tabs__item-link--active {
-    border-bottom-color: var(--rvo-tabs-active-border-bottom-color);
-    border-bottom-style: var(--rvo-tabs-active-border-bottom-style);
-    border-bottom-width: var(--rvo-tabs-active-border-bottom-width);
-    color: var(--rvo-tabs-active-color);
-    font-weight: var(--rvo-tabs-active-font-weight);
-  }
-  .rvo-tabs li.rvo-tabs__item .rvo-tabs__item-link--active:hover {
-    color: var(--rvo-tabs-active-hover-color);
-  }
-}
 /**
  * @license CC0-1.0
  * Copyright (c) 2021 Community for NL Design System
@@ -5754,6 +5798,42 @@ h6.rvo-heading .rvo-icon {
 
 /* stylelint-disable scss/dollar-variable-default */
 /* stylelint-enable scss/dollar-variable-default */
+.rvo-bg--violet {
+  background-color: var(--rvo-color-violet, #a90061) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-bg--violet-150 {
+  background-color: var(--rvo-color-violet-150, #F2D9E7) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-bg--violet-300 {
+  background-color: var(--rvo-color-violet-300, #E5B2CF) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-bg--violet-450 {
+  background-color: var(--rvo-color-violet-450, #D88CB7) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-bg--violet-600 {
+  background-color: var(--rvo-color-violet-600, #CB66A0) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-bg--violet-750 {
+  background-color: var(--rvo-color-violet-750, #BE4088) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
 .rvo-bg--grijs-050 {
   background-color: var(--rvo-color-grijs-050, #F8FAFC) !important;
 }
@@ -6114,6 +6194,42 @@ h6.rvo-heading .rvo-icon {
 
 /* stylelint-disable scss/dollar-variable-default */
 /* stylelint-enable scss/dollar-variable-default */
+.rvo-border--violet {
+  border-color: var(--rvo-color-violet, #a90061) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-border--violet-150 {
+  border-color: var(--rvo-color-violet-150, #F2D9E7) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-border--violet-300 {
+  border-color: var(--rvo-color-violet-300, #E5B2CF) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-border--violet-450 {
+  border-color: var(--rvo-color-violet-450, #D88CB7) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-border--violet-600 {
+  border-color: var(--rvo-color-violet-600, #CB66A0) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-border--violet-750 {
+  border-color: var(--rvo-color-violet-750, #BE4088) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
 .rvo-border--grijs-050 {
   border-color: var(--rvo-color-grijs-050, #F8FAFC) !important;
 }
@@ -6470,6 +6586,42 @@ h6.rvo-heading .rvo-icon {
 /* stylelint-enable scss/dollar-variable-default */
 .rvo-text--rood-750 {
   color: var(--rvo-color-rood-750, #E06056) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-text--violet {
+  color: var(--rvo-color-violet, #a90061) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-text--violet-150 {
+  color: var(--rvo-color-violet-150, #F2D9E7) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-text--violet-300 {
+  color: var(--rvo-color-violet-300, #E5B2CF) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-text--violet-450 {
+  color: var(--rvo-color-violet-450, #D88CB7) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-text--violet-600 {
+  color: var(--rvo-color-violet-600, #CB66A0) !important;
+}
+
+/* stylelint-disable scss/dollar-variable-default */
+/* stylelint-enable scss/dollar-variable-default */
+.rvo-text--violet-750 {
+  color: var(--rvo-color-violet-750, #BE4088) !important;
 }
 
 /* stylelint-disable scss/dollar-variable-default */

--- a/src/jinja_roos_components/static/roos/dist/@nl-rvo/design-tokens/index.css
+++ b/src/jinja_roos_components/static/roos/dist/@nl-rvo/design-tokens/index.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 05 Mar 2026 12:15:22 GMT
+ * Generated on Fri, 17 Apr 2026 08:13:37 GMT
  */
 
 .rvo-theme {
@@ -92,9 +92,10 @@
   --rvo-textbox-max-width: 100%;
   --rvo-textbox-outline-offset: 0;
   --rvo-tag-pill-border-radius: 25px;
-  --rvo-tabs-active-border-bottom-style: solid;
-  --rvo-tabs-hover-border-bottom-style: solid;
-  --rvo-tabs-border-bottom-style: solid;
+  --rvo-tabs-panel-border-width: 1px;
+  --rvo-tabs-panel-border-style: solid;
+  --rvo-tabs-border-width: 1px;
+  --rvo-tabs-border-style: solid;
   --rvo-table-cell-border-bottom-style: solid;
   --rvo-table-cell-border-bottom-width: 0.05rem;
   --rvo-table-header-size-xl: 75%;
@@ -278,6 +279,12 @@
   --rvo-color-grijs-200: #E2E8F0;
   --rvo-color-grijs-100: #F1F5F9;
   --rvo-color-grijs-050: #F8FAFC;
+  --rvo-color-violet-750: #BE4088;
+  --rvo-color-violet-600: #CB66A0;
+  --rvo-color-violet-450: #D88CB7;
+  --rvo-color-violet-300: #E5B2CF;
+  --rvo-color-violet-150: #F2D9E7;
+  --rvo-color-violet: #a90061;
   --rvo-color-rood-750: #E06056;
   --rvo-color-rood-600: #E68078;
   --rvo-color-rood-450: #EC9F99;
@@ -559,21 +566,27 @@
   --rvo-tag-padding-block-start: var(--rvo-space-2xs);
   --rvo-tag-padding-block-end: var(--rvo-space-2xs);
   --rvo-tag-border-radius: var(--rvo-border-radius-sm);
-  --rvo-tabs-active-hover-color: var(--rvo-color-grijs-700);
   --rvo-tabs-active-font-weight: var(--rvo-font-weight-bold);
-  --rvo-tabs-active-color: var(--rvo-color-hemelblauw);
-  --rvo-tabs-active-border-bottom-width: var(--rvo-size-3xs);
-  --rvo-tabs-active-border-bottom-color: var(--rvo-color-hemelblauw);
-  --rvo-tabs-hover-border-bottom-width: var(--rvo-size-3xs);
-  --rvo-tabs-hover-border-bottom-color: var(--rvo-color-zwart);
+  --rvo-tabs-active-color: var(--rvo-color-zwart);
+  --rvo-tabs-active-background: var(--rvo-color-wit);
+  --rvo-tabs-focus-width: var(--utrecht-focus-outline-width);
+  --rvo-tabs-focus-offset: var(--utrecht-focus-outline-offset);
+  --rvo-tabs-focus-color: var(--rvo-color-hemelblauw);
+  --rvo-tabs-panel-border-color: var(--rvo-color-grijs-400);
+  --rvo-tabs-panel-padding-inline-end: var(--rvo-space-md);
+  --rvo-tabs-panel-padding-inline-start: var(--rvo-space-md);
+  --rvo-tabs-panel-padding-block-end: var(--rvo-space-md);
+  --rvo-tabs-panel-padding-block-start: var(--rvo-space-md);
+  --rvo-tabs-gap: var(--rvo-space-2xs);
   --rvo-tabs-font-weight: var(--rvo-font-weight-normal);
+  --rvo-tabs-font-size: var(--rvo-font-size-md);
   --rvo-tabs-padding-inline-end: var(--rvo-space-md);
   --rvo-tabs-padding-inline-start: var(--rvo-space-md);
   --rvo-tabs-padding-block-end: var(--rvo-space-xs);
   --rvo-tabs-padding-block-start: var(--rvo-space-xs);
-  --rvo-tabs-color: var(--rvo-color-grijs-800);
-  --rvo-tabs-border-bottom-width: var(--rvo-size-3xs);
-  --rvo-tabs-border-bottom-color: var(--rvo-color-grijs-300);
+  --rvo-tabs-color: var(--rvo-color-donkerblauw);
+  --rvo-tabs-border-color: var(--rvo-color-grijs-400);
+  --rvo-tabs-background: var(--rvo-color-grijs-200);
   --rvo-table-cell-padding-inline-start: var(--rvo-space-md);
   --rvo-table-cell-padding-inline-end: var(--rvo-space-md);
   --rvo-table-cell-padding-block-start: var(--rvo-space-xs);
@@ -940,7 +953,7 @@
   --rvo-alert-padding-xs-padding-block-start: var(--rvo-space-xs);
   --rvo-alert-padding-xs-padding-block-end: var(--rvo-space-xs);
   --rvo-alert-success-background-color: var(--rvo-color-groen-300);
-  --rvo-alert-error-background-color: var(--rvo-color-rood-300);
+  --rvo-alert-error-background-color: var(--rvo-color-rood-150);
   --rvo-alert-warning-background-color: var(--rvo-color-donkergeel-300);
   --rvo-alert-info-background-color: var(--rvo-color-hemelblauw-300);
   --rvo-alert-line-height: var(--rvo-line-height-md);

--- a/src/jinja_roos_components/static/roos/dist/@nl-rvo/design-tokens/index.mjs
+++ b/src/jinja_roos_components/static/roos/dist/@nl-rvo/design-tokens/index.mjs
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 05 Mar 2026 12:15:22 GMT
+ * Generated on Fri, 17 Apr 2026 08:13:37 GMT
  */
 
 export const rvoBorderRadiusSm = "3px";
@@ -56,6 +56,12 @@ export const rvoColorRood300 = "#F3C0BC";
 export const rvoColorRood450 = "#EC9F99";
 export const rvoColorRood600 = "#E68078";
 export const rvoColorRood750 = "#E06056";
+export const rvoColorViolet = "#a90061";
+export const rvoColorViolet150 = "#F2D9E7";
+export const rvoColorViolet300 = "#E5B2CF";
+export const rvoColorViolet450 = "#D88CB7";
+export const rvoColorViolet600 = "#CB66A0";
+export const rvoColorViolet750 = "#BE4088";
 export const rvoColorGrijs050 = "#F8FAFC";
 export const rvoColorGrijs100 = "#F1F5F9";
 export const rvoColorGrijs200 = "#E2E8F0";
@@ -151,7 +157,7 @@ export const rvoAlertFieldsetMargin = "-24px";
 export const rvoAlertLineHeight = "150%";
 export const rvoAlertInfoBackgroundColor = "#B3D7EE";
 export const rvoAlertWarningBackgroundColor = "#FFE9B8";
-export const rvoAlertErrorBackgroundColor = "#F3C0BC";
+export const rvoAlertErrorBackgroundColor = "#F9DFDD";
 export const rvoAlertSuccessBackgroundColor = "#C4DBB7";
 export const rvoAlertPaddingXsPaddingBlockEnd = "8px";
 export const rvoAlertPaddingXsPaddingBlockStart = "8px";
@@ -639,24 +645,31 @@ export const rvoTableCellPaddingBlockEnd = "8px";
 export const rvoTableCellPaddingBlockStart = "8px";
 export const rvoTableCellPaddingInlineEnd = "16px";
 export const rvoTableCellPaddingInlineStart = "16px";
-export const rvoTabsBorderBottomColor = "#CBD5E1";
-export const rvoTabsBorderBottomStyle = "solid";
-export const rvoTabsBorderBottomWidth = "2px";
-export const rvoTabsColor = "#1E293B";
+export const rvoTabsBackground = "#E2E8F0";
+export const rvoTabsBorderColor = "#94A3B8";
+export const rvoTabsBorderStyle = "solid";
+export const rvoTabsBorderWidth = "1px";
+export const rvoTabsColor = "#01689b";
 export const rvoTabsPaddingBlockStart = "8px";
 export const rvoTabsPaddingBlockEnd = "8px";
 export const rvoTabsPaddingInlineStart = "16px";
 export const rvoTabsPaddingInlineEnd = "16px";
+export const rvoTabsFontSize = "1rem";
 export const rvoTabsFontWeight = "400";
-export const rvoTabsHoverBorderBottomColor = "#000000";
-export const rvoTabsHoverBorderBottomStyle = "solid";
-export const rvoTabsHoverBorderBottomWidth = "2px";
-export const rvoTabsActiveBorderBottomColor = "#007BC7";
-export const rvoTabsActiveBorderBottomStyle = "solid";
-export const rvoTabsActiveBorderBottomWidth = "2px";
-export const rvoTabsActiveColor = "#007BC7";
+export const rvoTabsGap = "4px";
+export const rvoTabsPanelPaddingBlockStart = "16px";
+export const rvoTabsPanelPaddingBlockEnd = "16px";
+export const rvoTabsPanelPaddingInlineStart = "16px";
+export const rvoTabsPanelPaddingInlineEnd = "16px";
+export const rvoTabsPanelBorderColor = "#94A3B8";
+export const rvoTabsPanelBorderStyle = "solid";
+export const rvoTabsPanelBorderWidth = "1px";
+export const rvoTabsFocusColor = "#007BC7";
+export const rvoTabsFocusOffset = "3px";
+export const rvoTabsFocusWidth = "2px";
+export const rvoTabsActiveBackground = "#FFFFFF";
+export const rvoTabsActiveColor = "#000000";
 export const rvoTabsActiveFontWeight = "700";
-export const rvoTabsActiveHoverColor = "#334155";
 export const rvoTagBorderRadius = "3px";
 export const rvoTagPaddingBlockEnd = "4px";
 export const rvoTagPaddingBlockStart = "4px";


### PR DESCRIPTION
## Summary
- Bumps `@nl-rvo/component-library-css` from 4.19.0 to 4.20.1
- Bumps `@nl-rvo/design-tokens` from 2.2.0 to 2.4.0
- Rebuilds static assets with new dependencies

This update adds CSS support for the new RVO tabs v2 component (`rvo-tabs__tablist`, `rvo-tabs__tab`, `rvo-tabs__panel`) and the matching design tokens. Without this update, projects using the new tabs markup get unstyled buttons.

## Test plan
- [x] Verify existing components still render correctly
- [x] Verify new tabs markup renders with proper styling