### PR TITLE
Add Link and Tabs stories, improve render API

### DIFF
--- a/storybook/helpers/formatHtml.js
+++ b/storybook/helpers/formatHtml.js
@@ -1,0 +1,19 @@
+const selfClosing = new Set(["c-icon", "c-status-icon"]);
+
+export function formatHtml(source) {
+  if (!source) return source;
+  let formatted = "";
+  let indent = 0;
+  const tokens = source.replace(/>\s*</g, ">\n<").split("\n");
+  for (const token of tokens) {
+    const trimmed = token.trim();
+    if (!trimmed) continue;
+    if (/^<\//.test(trimmed)) indent--;
+    formatted += "  ".repeat(Math.max(indent, 0)) + trimmed + "\n";
+    if (/^<[^/]/.test(trimmed) && !/>.*<\//.test(trimmed) && !/\/>$/.test(trimmed)) {
+      const tagMatch = trimmed.match(/^<([\w-]+)/);
+      if (tagMatch && !selfClosing.has(tagMatch[1])) indent++;
+    }
+  }
+  return formatted.trimEnd();
+}

--- a/storybook/helpers/renderComponent.js
+++ b/storybook/helpers/renderComponent.js
@@ -1,4 +1,4 @@
-const API_BASE = "http://localhost:8100";
+const API_BASE = "http://127.0.0.1:8100";
 
 export async function renderComponent(component, attrs = {}, content = "") {
   let res;

--- a/storybook/helpers/renderVariants.js
+++ b/storybook/helpers/renderVariants.js
@@ -1,0 +1,66 @@
+import { renderComponent } from "./renderComponent";
+import { buildSource } from "./buildSource";
+
+/**
+ * Render multiple component variants in a grid with labels and code blocks.
+ *
+ * @param {string} componentName - The component tag name (e.g. "button")
+ * @param {Array<{label: string, args: object}>} variants - Array of variant definitions
+ * @param {object} [options] - Optional settings
+ * @param {string} [options.previewStyle] - CSS for each preview wrapper
+ * @returns {HTMLElement} A grid container with all variants rendered
+ */
+export async function renderVariants(componentName, variants, options = {}) {
+  const results = await Promise.all(
+    variants.map(async ({ label, args }) => {
+      const { content, ...attrs } = args;
+      const rendered = await renderComponent(
+        componentName,
+        attrs,
+        content || "",
+      );
+      const source = buildSource(componentName, args);
+      return { label, html: rendered.html, source };
+    }),
+  );
+
+  const grid = document.createElement("div");
+  grid.className = "variant-grid";
+
+  for (const { label, html, source } of results) {
+    const card = document.createElement("div");
+    card.className = "variant-card";
+
+    const labelEl = document.createElement("h3");
+    labelEl.className = "variant-label";
+    labelEl.textContent = label;
+    card.appendChild(labelEl);
+
+    const preview = document.createElement("div");
+    preview.className = "variant-preview";
+    if (options.previewStyle) {
+      preview.style.cssText = options.previewStyle;
+    }
+    preview.innerHTML = html;
+    // Contain dialog elements within their preview box
+    preview.querySelectorAll("dialog").forEach(d => {
+      d.style.position = "relative";
+      d.style.inset = "unset";
+      d.style.maxHeight = "none";
+      d.style.maxWidth = "100%";
+      d.style.width = "100%";
+    });
+    card.appendChild(preview);
+
+    const codeBlock = document.createElement("pre");
+    codeBlock.className = "variant-code";
+    const codeEl = document.createElement("code");
+    codeEl.textContent = source;
+    codeBlock.appendChild(codeEl);
+    card.appendChild(codeBlock);
+
+    grid.appendChild(card);
+  }
+
+  return grid;
+}

--- a/storybook/render_api.py
+++ b/storybook/render_api.py
@@ -75,6 +75,10 @@ def escape_attr(value: str) -> str:
     return str(value).replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;").replace(">", "&gt;")
 
 
+# Attributes that contain component markup and must not be escaped
+HTML_CONTENT_ATTRS = frozenset({"footer", "content"})
+
+
 def strip_template_syntax(value: str) -> str:
     """Remove Jinja2 template syntax to prevent SSTI."""
     return value.replace("{{", "").replace("}}", "").replace("{%", "").replace("%}", "")
@@ -92,29 +96,65 @@ def render_component(req: RenderRequest):
         if not ATTR_NAME_RE.match(key):
             raise HTTPException(status_code=400, detail=f"Invalid attribute name: {key}")
 
+    # Parse JSON string values into lists/dicts (Storybook sends text controls as strings)
+    import json as _json
+    for key, value in list(req.attrs.items()):
+        if isinstance(value, str) and value.startswith("["):
+            try:
+                req.attrs[key] = _json.loads(value)
+            except _json.JSONDecodeError:
+                pass
+
     source = build_source(req.component, req.attrs, req.content)
 
-    # Build template string with escaped values
-    attrs_str = ""
-    for key, value in req.attrs.items():
-        if isinstance(value, bool):
-            attrs_str += f' {key}="{str(value).lower()}"'
-        elif value is not None and value != "":
-            attrs_str += f' {key}="{escape_attr(value)}"'
+    # Check if any attribute contains component markup or complex objects (lists/dicts)
+    has_component_attrs = any(
+        (key in HTML_CONTENT_ATTRS and isinstance(value, str) and "<c-" in value)
+        or isinstance(value, (list, dict))
+        for key, value in req.attrs.items()
+    )
 
-    # Strip any Jinja2 template syntax from content to prevent SSTI
-    content = strip_template_syntax(req.content) if req.content else ""
-
-    if content:
-        template_str = f"<c-{req.component}{attrs_str}>{content}</c-{req.component}>"
+    if has_component_attrs:
+        # Render directly via the component template to avoid quote-escaping issues
+        context = {}
+        for key, value in req.attrs.items():
+            if key in HTML_CONTENT_ATTRS and isinstance(value, str) and "<c-" in value:
+                # Pre-render component markup in this attribute
+                sanitized = strip_template_syntax(value)
+                tpl = jinja_env.from_string(sanitized)  # nosec B703
+                context[key] = tpl.render()
+            else:
+                context[key] = value
+        # Add content as the 'content' key
+        if req.content:
+            content = strip_template_syntax(req.content)
+            if "<c-" in content:
+                tpl = jinja_env.from_string(content)  # nosec B703
+                context["content"] = tpl.render()
+            else:
+                context["content"] = content
+        # Render the component template directly with _component_context
+        template = jinja_env.get_template(f"components/{req.component}.html.j2")
+        html = template.render(_component_context=context)
     else:
-        template_str = f"<c-{req.component}{attrs_str} />"
+        # Standard path: build <c-*> tag string for the preprocessor
+        attrs_str = ""
+        for key, value in req.attrs.items():
+            if isinstance(value, bool):
+                attrs_str += f' {key}="{str(value).lower()}"'
+            elif value is not None and value != "":
+                attrs_str += f' {key}="{escape_attr(value)}"'
 
-    # Safe: component name is validated against allowlist, attrs are escaped,
-    # content is stripped of template syntax. from_string is needed because
-    # the component extension preprocesses <c-*> tags at parse time.
-    template = jinja_env.from_string(template_str)  # nosec B703
-    html = template.render()
+        content = strip_template_syntax(req.content) if req.content else ""
+
+        if content:
+            template_str = f"<c-{req.component}{attrs_str}>{content}</c-{req.component}>"
+        else:
+            template_str = f"<c-{req.component}{attrs_str} />"
+
+        template = jinja_env.from_string(template_str)  # nosec B703
+        html = template.render()
+
     return RenderResponse(html=html, source=source)
 
 

--- a/storybook/stories/Link.stories.js
+++ b/storybook/stories/Link.stories.js
@@ -1,0 +1,96 @@
+import { formatHtml } from "../helpers/formatHtml";
+import { renderComponent } from "../helpers/renderComponent";
+import { buildSource } from "../helpers/buildSource";
+
+const meta = {
+  title: "Componenten/Link",
+  argTypes: {
+    label: { control: { type: "text" }, description: "Link tekst" },
+    href: { control: { type: "text" }, description: "URL", table: { defaultValue: { summary: "#" } } },
+    icon: { control: { type: "text" }, description: "Icoon naam (bijv. delta-naar-rechts, externe-link)" },
+    iconPlacement: { options: ["before", "after"], control: { type: "inline-radio" }, description: "Icoon positie", table: { defaultValue: { summary: "before" } } },
+    iconSize: { options: ["xs", "sm", "md", "lg"], control: { type: "inline-radio" }, description: "Icoon grootte", table: { defaultValue: { summary: "sm" } } },
+    noUnderline: { control: { type: "boolean" }, description: "Geen underline", table: { defaultValue: { summary: "false" } } },
+    color: { options: ["", "lintblauw", "hemelblauw", "donkerblauw", "grijs-700", "zwart"], control: { type: "select" }, description: "Link kleur" },
+    weight: { options: ["", "normal", "bold"], control: { type: "select" }, description: "Font weight" },
+    target: { options: ["", "_blank"], control: { type: "select" }, description: "Target" },
+  },
+  parameters: {
+    docs: {
+      source: {
+        language: "html",
+        transform: (_code, ctx) => buildSource("link", ctx.args),
+      },
+    },
+  },
+  loaders: [
+    async ({ args }) => {
+      const { label, ...attrs } = args;
+      return await renderComponent("link", attrs, label || "");
+    },
+  ],
+  render: (_args, { loaded: { html, source } }) => {
+    const container = document.createElement("div");
+    const preview = document.createElement("div");
+    preview.innerHTML = html;
+    container.appendChild(preview);
+    if (source) {
+      const codeBlock = document.createElement("pre");
+      codeBlock.className = "variant-code";
+      const codeEl = document.createElement("code");
+      codeEl.textContent = formatHtml(source);
+      codeBlock.appendChild(codeEl);
+      codeBlock.style.marginTop = "16px";
+      codeBlock.style.borderRadius = "6px";
+      container.appendChild(codeBlock);
+    }
+    return container;
+  },
+};
+
+export default meta;
+
+export const Default = {
+  name: "Link",
+  args: {
+    label: "Voorbeeld link",
+    href: "#",
+    icon: "",
+    iconPlacement: "before",
+    iconSize: "sm",
+    noUnderline: false,
+    color: "",
+    weight: "",
+    target: "",
+  },
+};
+
+export const WithIcon = {
+  name: "Met icoon",
+  args: {
+    label: "Privacy",
+    href: "#",
+    icon: "delta-naar-rechts",
+    iconPlacement: "before",
+    iconSize: "xs",
+    noUnderline: false,
+    color: "zwart",
+    weight: "normal",
+    target: "",
+  },
+};
+
+export const External = {
+  name: "Externe link",
+  args: {
+    label: "GitHub",
+    href: "https://github.com",
+    icon: "externe-link",
+    iconPlacement: "after",
+    iconSize: "xs",
+    noUnderline: false,
+    color: "",
+    weight: "",
+    target: "_blank",
+  },
+};

--- a/storybook/stories/Tabs.stories.js
+++ b/storybook/stories/Tabs.stories.js
@@ -1,0 +1,70 @@
+import { formatHtml } from "../helpers/formatHtml";
+import { renderComponent } from "../helpers/renderComponent";
+import { buildSource } from "../helpers/buildSource";
+
+const meta = {
+  title: "Componenten/Tabs",
+  argTypes: {
+    tabLabels: { control: { type: "text" }, description: "Tab labels (komma-gescheiden)", table: { defaultValue: { summary: "Gegevens, Updates" } } },
+    activeTab: { control: { type: "number" }, description: "Actieve tab (0-based)", table: { defaultValue: { summary: "0" } } },
+    size: { options: ["sm", "md", "lg"], control: { type: "inline-radio" }, description: "Formaat", table: { defaultValue: { summary: "md" } } },
+    variant: { options: ["default", "borderless"], control: { type: "inline-radio" }, description: "Stijlvariant", table: { defaultValue: { summary: "default" } } },
+    ariaLabel: { control: { type: "text" }, description: "Aria label voor de tablist", table: { defaultValue: { summary: "Tabs" } } },
+  },
+  parameters: {
+    docs: {
+      source: {
+        language: "html",
+        transform: (_code, ctx) => {
+          const { tabLabels, ...rest } = ctx.args;
+          return buildSource("tabs", { ...rest, tabs: parseTabs(tabLabels) });
+        },
+      },
+    },
+  },
+  loaders: [
+    async ({ args }) => {
+      const { tabLabels, ...attrs } = args;
+      const tabs = parseTabs(tabLabels);
+      const panelContent = `<div class="rvo-tabs__panel" role="tabpanel" tabindex="0"><p>Inhoud van tab ${(attrs.activeTab || 0) + 1}.</p></div>`;
+      return await renderComponent("tabs", { ...attrs, tabs: JSON.stringify(tabs) }, panelContent);
+    },
+  ],
+  render: (_args, { loaded: { html, source } }) => {
+    const container = document.createElement("div");
+    const preview = document.createElement("div");
+    preview.innerHTML = html;
+    container.appendChild(preview);
+    if (source) {
+      const codeBlock = document.createElement("pre");
+      codeBlock.className = "variant-code";
+      const codeEl = document.createElement("code");
+      codeEl.textContent = formatHtml(source);
+      codeBlock.appendChild(codeEl);
+      codeBlock.style.marginTop = "16px";
+      codeBlock.style.borderRadius = "6px";
+      container.appendChild(codeBlock);
+    }
+    return container;
+  },
+};
+
+function parseTabs(labels) {
+  return (labels || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((label) => ({ label }));
+}
+
+export default meta;
+
+export const Playground = {
+  name: "Tabs",
+  args: {
+    tabLabels: "Gegevens, Updates, Notities",
+    activeTab: 0,
+    size: "md",
+    variant: "default",
+  },
+};


### PR DESCRIPTION
## Summary
- **Link story**: default, met icoon (zwart/normal), externe link varianten
- **Tabs story**: interactieve controls voor labels, size, variant (default/borderless)
- **Render API**: parse JSON string attrs van Storybook text controls
- **Render API**: gebruik `127.0.0.1` i.p.v. `localhost` om IPv4/IPv6 mismatch te voorkomen
- **Helpers**: `formatHtml` en `renderVariants` utilities toegevoegd

> **Note:** deze PR is onafhankelijk van component-fixes (#29) maar de stories werken het best samen.

## Test plan
- [ ] Storybook toont Link component met 3 varianten
- [ ] Storybook toont Tabs component met controls voor labels, size, variant
- [ ] Render API start zonder errors op port 8100
- [ ] Tabs met JSON string attrs renderen correct